### PR TITLE
Postを本人以外修正・削除できないようにしました。userの登録で名前を重複しないようにしました

### DIFF
--- a/php/views/Core/RedirectTarget.php
+++ b/php/views/Core/RedirectTarget.php
@@ -7,6 +7,7 @@ class RedirectTarget
 {
     private const HOME_PATH = "/";
     private const LOGIN_PATH = "/login";
+    private const REGISTER_PATH = "/register";
 
     public static function getHomePath(): string
     {
@@ -16,5 +17,10 @@ class RedirectTarget
     public static function getLoginPath(): string
     {
         return self::LOGIN_PATH;
+    }
+
+    public static function getRegisterPath(): string
+    {
+        return self::REGISTER_PATH;
     }
 }

--- a/php/views/Core/Request.php
+++ b/php/views/Core/Request.php
@@ -70,7 +70,7 @@ class Request
      */
     private function isUriValid(string $uri): bool
     {
-        if (preg_match(pattern: '/^([\/]?([a-zA-Z]+)*(\?[a-zA-Z]+=[a-zA-Z0-9]+)?)$/', subject: $uri)) {
+        if (preg_match(pattern: '/^([\/]?([a-zA-Z\-]+)*(\?[a-zA-Z]+=[a-zA-Z0-9]+)?)$/', subject: $uri)) {
             return true;
         } else {
             return false;

--- a/php/views/Core/StringArray.php
+++ b/php/views/Core/StringArray.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+use InvalidArgumentException;
+
+class StringArray
+{
+    private int $length = 0;
+
+    private array $arr;
+
+    public function __construct(array $arr)
+    {
+        foreach ($arr as $key => $value) {
+            // if array type is not `string[]` throw exception
+            if ($this->length !== $key) {
+                throw new InvalidArgumentException(message: 'Array is not sequential');
+            }
+            $this->length++;
+
+            if (!is_string($value)) {
+                throw new InvalidArgumentException(message: 'StringArray\'s value type must be string');
+            }
+        }
+        $this->arr = $arr;
+    }
+
+    public function getLength(): int
+    {
+        return $this->length;
+    }
+
+    // type of object which returned is MUST `string[]` because of constructor\'s function
+    public function getArr(): array
+    {
+        return $this->arr;
+    }
+
+    public function isExist(string $str): bool
+    {
+        foreach ($this->arr as $item) {
+            if ($item === $str) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/php/views/Core/StringArrayChecker.php
+++ b/php/views/Core/StringArrayChecker.php
@@ -6,7 +6,7 @@ namespace App\Core;
 
 use InvalidArgumentException;
 
-class StringArray
+class StringArrayChecker
 {
     private int $length = 0;
 
@@ -22,7 +22,7 @@ class StringArray
             $this->length++;
 
             if (!is_string($value)) {
-                throw new InvalidArgumentException(message: 'StringArray\'s value type must be string');
+                throw new InvalidArgumentException(message: 'StringArrayChecker\'s value type must be string');
             }
         }
         $this->arr = $arr;
@@ -41,10 +41,8 @@ class StringArray
 
     public function isExist(string $str): bool
     {
-        foreach ($this->arr as $item) {
-            if ($item === $str) {
-                return true;
-            }
+        if (in_array($str, $this->arr, strict: true)) {
+            return true;
         }
         return false;
     }

--- a/php/views/Handler/HandlerLogout.php
+++ b/php/views/Handler/HandlerLogout.php
@@ -10,10 +10,9 @@ use App\Core\Response;
 
 class HandlerLogout implements HandlerInterface
 {
-    // TODO: after implementation of authentication, change router to redirect to login page
     public static function run(Request $req): Response
     {
-        unset($_SESSION['user_id']);
+        unset($_SESSION['user_name']);
         return new Response(
             status_code: "301"
             , body: "ok, redirect to login page"

--- a/php/views/Handler/HandlerNotAuthor.php
+++ b/php/views/Handler/HandlerNotAuthor.php
@@ -6,7 +6,6 @@ namespace App\Handler;
 
 use App\Core\Request;
 use App\Core\Response;
-use App\Core\RedirectTarget;
 use App\Html\CreateBadRequestHtml;
 
 class HandlerNotAuthor implements HandlerInterface

--- a/php/views/Handler/HandlerNotAuthor.php
+++ b/php/views/Handler/HandlerNotAuthor.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Handler;
+
+use App\Core\Request;
+use App\Core\Response;
+use App\Core\RedirectTarget;
+use App\Html\CreateBadRequestHtml;
+
+class HandlerNotAuthor implements HandlerInterface
+{
+    public static function run(Request $req): Response
+    {
+        $html = new CreateBadRequestHtml();
+        return new Response(
+            status_code: "403"
+            , body: $html->getHtml()
+        );
+    }
+}

--- a/php/views/Handler/HandlerRegister.php
+++ b/php/views/Handler/HandlerRegister.php
@@ -6,38 +6,65 @@ namespace App\Handler;
 use App\Core\RedirectTarget;
 use App\Core\Request;
 use App\Core\Response;
-use App\Html\CreateBadRequestHtml;
 use App\Html\CreateInternalServerErrorHtml;
 use App\Repository\RepositoryRegister;
+use InvalidArgumentException;
 use PDOException;
 
 class HandlerRegister
 {
     public static function run(Request $req): Response
     {
+        if (self::isFormFilled(req: $req) === false) {
+            $html = "空欄があります。全て入力してから送信してください。";
+            return new Response(
+                status_code: "400"
+                , body: $html
+                , redirect_location: RedirectTarget::getRegisterPath()
+            );
+        }
+        return self::requestDB(req: $req);
+    }
+
+    private static function isFormFilled(Request $req): bool
+    {
         if ($req->getPostData()["username"] !== "" && $req->getPostData()["password"] !== "") {
-            try {
-                $username = $req->getPostData()["username"];
-                $email = $req->getPostData()["email"];
-                $password_hashed = password_hash($req->getPostData()["password"], PASSWORD_DEFAULT);
-                RepositoryRegister::RegisterUser(
-                    user_name: $username
-                    , email: $email
-                    , password_hashed: $password_hashed
-                );
-                $html = "ok, redirect to top page";
-                return new Response(
-                    status_code: "301"
-                    , body: $html
-                    , redirect_location: RedirectTarget::getHomePath()
-                );
-            } catch (PDOException) {
-                $html = new CreateInternalServerErrorHtml();
-                return new Response(status_code: "500", body: $html->getHtml());
-            }
+            return true;
         } else {
-            $html = new CreateBadRequestHtml();
-            return new Response(status_code: "403", body: $html->getHtml());
+            return false;
+        }
+
+    }
+
+    private static function requestDB(Request $req): Response
+    {
+        try {
+            $username = $req->getPostData()["username"];
+            $email = $req->getPostData()["email"];
+            $password_hashed = password_hash($req->getPostData()["password"], algo: PASSWORD_DEFAULT);
+            RepositoryRegister::RegisterUser(
+                user_name: $username
+                , email: $email
+                , password_hashed: $password_hashed
+            );
+            $html = "ok, redirect to top page";
+            return new Response(
+                status_code: "301"
+                , body: $html
+                , redirect_location: RedirectTarget::getHomePath()
+            );
+        } catch (PDOException) {
+            // ERROR from System
+            $html = new CreateInternalServerErrorHtml();
+            return new Response(status_code: "500", body: $html->getHtml());
+        } catch (InvalidArgumentException) {
+            // ERROR from User Input
+            $html = "この名前は登録できません。すでに登録されています。";
+            return new Response(
+                status_code: "400"
+                , body: $html
+                , redirect_location: RedirectTarget::getRegisterPath()
+            );
         }
     }
 }

--- a/php/views/Handler/HandlerTopPage.php
+++ b/php/views/Handler/HandlerTopPage.php
@@ -19,7 +19,9 @@ class HandlerTopPage implements HandlerInterface
             $posts = RepositoryGetAllPost::getAllPosts();
             $html = new CreateTopPageHtml($posts);
             return new Response(status_code: '200', body: $html->getHtml());
-        } catch (PDOException) {
+        } catch (PDOException $e) {
+            echo $e;
+            die;
             $html = new CreateInternalServerErrorHtml();
             return new Response(status_code: '500', body: $html->getHtml());
         }

--- a/php/views/Html/CreatePostPageHtml.php
+++ b/php/views/Html/CreatePostPageHtml.php
@@ -40,7 +40,7 @@ class CreatePostPageHtml extends HtmlTemplate implements HtmlInterface
         $main .= '<div class="my-5 bg-slate-800 p-10 rounded-xl">';
         $main .= '<h2 class="text-3xl text-monokaiGreen"><span class="text-monokaiRed">Title: </span>' . $post->getTitle() . '</h2>';
         $main .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">User_Name: </span>' . $post->getUserName() . '</p>';
-        $main .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">Created_At: </span>' . substr(string: $post->getCreatedAt(), offset: 0, length:10). '</p>';
+        $main .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">Created_At: </span>' . substr(string: $post->getCreatedAt(), offset: 0, length: 10) . '</p>';
         $main .= '<img class="my-4 object-contain rounded-xl" src=' . $post->getThumbnail() . ' alt="image">';
         $main .= '<p class="text-md text-monokaiWhite">' . $post->getBody() . '</p>';
         $main .= '</div>';
@@ -53,13 +53,13 @@ class CreatePostPageHtml extends HtmlTemplate implements HtmlInterface
 
     private function getMenu(string $id): string
     {
-        $edit_action = $this->isAuthorOfPost ? "/edit?id=".$id  : "/not-author";
+        $edit_action = $this->isAuthorOfPost ? "/edit?id=" . $id : "/not-author";
         $menu = '<div class="flex text-monokaiWhite text-lg py-10">';
-        $menu .= '<a href="'.$edit_action.'" class="inline-block w-[50%] text-center hover:font-bold pr-5 rounded-xl py-10"><div class="inline-block text-center w-full text-center hover:font-bold pr-5 rounded-xl bg-monokaiGreen py-3">Edit</div></a>';
+        $menu .= '<a href="' . $edit_action . '" class="inline-block w-[50%] text-center hover:font-bold pr-5 rounded-xl py-10"><div class="inline-block text-center w-full text-center hover:font-bold pr-5 rounded-xl bg-monokaiGreen py-3">Edit</div></a>';
 
-        $delete_action = $this->isAuthorOfPost ? "/delete?id=".$id : "/not-author";
+        $delete_action = $this->isAuthorOfPost ? "/delete?id=" . $id : "/not-author";
         $menu .= '<input type="hidden" name="_method" value="delete">';
-        $menu .= '<form method="POST" action="'. $delete_action . '" class="inline-block w-[50%] text-monokaiWhite text-lg py-10 pl-5">';
+        $menu .= '<form method="POST" action="' . $delete_action . '" class="inline-block w-[50%] text-monokaiWhite text-lg py-10 pl-5">';
         $menu .= '<button type="submit" class="w-full text-center hover:font-bold pr-5 rounded-xl bg-monokaiRed py-3">Delete</button>';
         $menu .= '</form></div>';
         return $menu;

--- a/php/views/Html/CreatePostPageHtml.php
+++ b/php/views/Html/CreatePostPageHtml.php
@@ -4,41 +4,47 @@ declare(strict_types=1);
 
 namespace App\Html;
 
-use App\Model\PostCollection;
+use App\Model\Post;
 
 class CreatePostPageHtml extends HtmlTemplate implements HtmlInterface
 {
     private string $html;
+    private bool $isAuthorOfPost;
 
-    public function __construct(PostCollection $post_collection)
+    public function __construct(Post $post)
     {
+        // Server have session because of function on Router (isUserLoggedIn)
+        if ($post->getUserName() === $_SESSION["user_name"]) {
+            $this->isAuthorOfPost = true;
+        } else {
+            $this->isAuthorOfPost = false;
+        }
+
         $html = '<!DOCTYPE html>';
         $html .= '<html lang="jp">';
         $html .= $this->getHead();
         $html .= '<body class="bg-slate-700 text-white px-[30%] my-10">';
         $html .= $this->getHeader();
         $html .= $this->getNavbar();
-        $html .= $this->getMain($post_collection);
+        $html .= $this->getMain($post);
         $html .= $this->getFooter();
         $html .= '</body>';
         $html .= '</html>';
         $this->html = $html;
+
     }
 
-    public function getMain(PostCollection $posts): string
+    public function getMain(Post $post): string
     {
         $main = '<body>';
-        foreach ($posts as $post) {
-            if ($post->getId() == $_GET['id']) {
-                $main .= '<div class="my-5 bg-slate-800 p-10 rounded-xl">';
-                $main .= '<h2 class="text-3xl text-monokaiGreen"><span class="text-monokaiRed">Title: </span>' . $post->getTitle() . '</h2>';
-                $main .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">User_Name: </span>' . $post->getUserName() . '</p>';
-                $main .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">Created_At: </span>' . substr(string: $post->getCreatedAt(), offset: 0, length:10). '</p>';
-                $main .= '<img class="my-4 object-contain rounded-xl" src=' . $post->getThumbnail() . ' alt="image">';
-                $main .= '<p class="text-md text-monokaiWhite">' . $post->getBody() . '</p>';
-                $main .= '</div>';
-            }
-        }
+        $main .= '<div class="my-5 bg-slate-800 p-10 rounded-xl">';
+        $main .= '<h2 class="text-3xl text-monokaiGreen"><span class="text-monokaiRed">Title: </span>' . $post->getTitle() . '</h2>';
+        $main .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">User_Name: </span>' . $post->getUserName() . '</p>';
+        $main .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">Created_At: </span>' . substr(string: $post->getCreatedAt(), offset: 0, length:10). '</p>';
+        $main .= '<img class="my-4 object-contain rounded-xl" src=' . $post->getThumbnail() . ' alt="image">';
+        $main .= '<p class="text-md text-monokaiWhite">' . $post->getBody() . '</p>';
+        $main .= '</div>';
+
         $id = $_GET['id'];
         $main .= $this->getMenu($id);
         $main .= '</body>';
@@ -47,10 +53,13 @@ class CreatePostPageHtml extends HtmlTemplate implements HtmlInterface
 
     private function getMenu(string $id): string
     {
+        $edit_action = $this->isAuthorOfPost ? "/edit?id=".$id  : "/not-author";
         $menu = '<div class="flex text-monokaiWhite text-lg py-10">';
-        $menu .= '<a href="/edit?id=' . $id . '" class="inline-block w-[50%] text-center hover:font-bold pr-5 rounded-xl py-10"><div class="inline-block text-center w-full text-center hover:font-bold pr-5 rounded-xl bg-monokaiGreen py-3">Edit</div></a>';
-        $menu .= '<form method="POST" action="/post?id=' . $id . '" class="inline-block w-[50%] text-monokaiWhite text-lg py-10 pl-5">';
+        $menu .= '<a href="'.$edit_action.'" class="inline-block w-[50%] text-center hover:font-bold pr-5 rounded-xl py-10"><div class="inline-block text-center w-full text-center hover:font-bold pr-5 rounded-xl bg-monokaiGreen py-3">Edit</div></a>';
+
+        $delete_action = $this->isAuthorOfPost ? "/delete?id=".$id : "/not-author";
         $menu .= '<input type="hidden" name="_method" value="delete">';
+        $menu .= '<form method="POST" action="'. $delete_action . '" class="inline-block w-[50%] text-monokaiWhite text-lg py-10 pl-5">';
         $menu .= '<button type="submit" class="w-full text-center hover:font-bold pr-5 rounded-xl bg-monokaiRed py-3">Delete</button>';
         $menu .= '</form></div>';
         return $menu;

--- a/php/views/Html/CreatePostPageHtml.php
+++ b/php/views/Html/CreatePostPageHtml.php
@@ -27,21 +27,22 @@ class CreatePostPageHtml extends HtmlTemplate implements HtmlInterface
 
     public function getMain(PostCollection $posts): string
     {
-        $body = '<body>';
+        $main = '<body>';
         foreach ($posts as $post) {
             if ($post->getId() == $_GET['id']) {
-                $body .= '<div class="my-5 bg-slate-800 p-10 rounded-xl">';
-                $body .= '<h2 class="text-3xl text-monokaiGreen"><span class="text-monokaiRed">Title: </span>' . $post->getTitle() . '</h2>';
-                $body .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">Created_At: </span>' . $post->getCreatedAt() . '</p>';
-                $body .= '<img class="my-4 object-contain rounded-xl" src=' . $post->getThumbnail() . ' alt="image">';
-                $body .= '<p class="text-md text-monokaiWhite">' . $post->getBody() . '</p>';
-                $body .= '</div>';
+                $main .= '<div class="my-5 bg-slate-800 p-10 rounded-xl">';
+                $main .= '<h2 class="text-3xl text-monokaiGreen"><span class="text-monokaiRed">Title: </span>' . $post->getTitle() . '</h2>';
+                $main .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">User_Name: </span>' . $post->getUserName() . '</p>';
+                $main .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">Created_At: </span>' . substr(string: $post->getCreatedAt(), offset: 0, length:10). '</p>';
+                $main .= '<img class="my-4 object-contain rounded-xl" src=' . $post->getThumbnail() . ' alt="image">';
+                $main .= '<p class="text-md text-monokaiWhite">' . $post->getBody() . '</p>';
+                $main .= '</div>';
             }
         }
         $id = $_GET['id'];
-        $body .= $this->getMenu($id);
-        $body .= '</body>';
-        return $body;
+        $main .= $this->getMenu($id);
+        $main .= '</body>';
+        return $main;
     }
 
     private function getMenu(string $id): string

--- a/php/views/Html/CreateRegisterPageHtml.php
+++ b/php/views/Html/CreateRegisterPageHtml.php
@@ -25,7 +25,15 @@ class CreateRegisterPageHtml extends HtmlTemplate implements HtmlInterface
 
     private function getMain(): string
     {
-        $main = '<form method="POST" action="/register" class="my-10">';
+        $main = "";
+        if (!empty($_SESSION['message'])) {
+            $main .= '<div class="bg-monokaiRed px-5 py-3 my-3 rounded-lg">';
+            $main .= '<h1">403 Bad Request</h1>';
+            $main .= '<p class="text-monokaiWhite font-bold">' . $_SESSION['message'] . '</p>';
+            $main .= '</div>';
+            unset($_SESSION['message']);
+        }
+        $main .= '<form method="POST" action="/register" class="my-10">';
         $main .= '<h2 class="text-3xl text-monokaiWhite my-3">Register</h2>';
         $main .= '<label class="text-monokaiGreen text-lg font-bold">USER NAME</label>';
         $main .= '<input type="text" name="username" placeholder="username" class="text-slate-800 h-16 w-full rounded-lg bg-monokaiWhite px-16 py-5 my-5">';

--- a/php/views/Html/CreateTopPageHtml.php
+++ b/php/views/Html/CreateTopPageHtml.php
@@ -35,7 +35,7 @@ class CreateTopPageHtml extends HtmlTemplate implements HtmlInterface
             $main .= '<a href="/post?id=' . $post->getId() . '">';
             $main .= '<h2 class="text-3xl text-monokaiGreen"><span class="text-monokaiRed">Title: </span>' . $post->getTitle() . '</h2>';
             $main .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">User_Name: </span>' . $post->getUserName() . '</p>';
-            $main .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">Created_At: </span>' . substr(string:$post->getCreatedAt(), offset: 0, length:10 ). '</p>';
+            $main .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">Created_At: </span>' . substr(string: $post->getCreatedAt(), offset: 0, length: 10) . '</p>';
             $main .= '<img class="my-4 object-contain rounded-xl" src=' . $post->getThumbnail() . ' alt="image">';
             $main .= '<p class="text-md text-monokaiWhite">' . substr(string: $post->getBody(), offset: 0, length: 100) . '...</p>';
             $main .= '</a>';

--- a/php/views/Html/CreateTopPageHtml.php
+++ b/php/views/Html/CreateTopPageHtml.php
@@ -34,7 +34,8 @@ class CreateTopPageHtml extends HtmlTemplate implements HtmlInterface
             $main .= '<div class="my-16 bg-slate-800 p-10 rounded-xl">';
             $main .= '<a href="/post?id=' . $post->getId() . '">';
             $main .= '<h2 class="text-3xl text-monokaiGreen"><span class="text-monokaiRed">Title: </span>' . $post->getTitle() . '</h2>';
-            $main .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">Created_At: </span>' . $post->getCreatedAt() . '</p>';
+            $main .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">User_Name: </span>' . $post->getUserName() . '</p>';
+            $main .= '<p class="text-monokaiYellow"><span class="text-monokaiOrange">Created_At: </span>' . substr(string:$post->getCreatedAt(), offset: 0, length:10 ). '</p>';
             $main .= '<img class="my-4 object-contain rounded-xl" src=' . $post->getThumbnail() . ' alt="image">';
             $main .= '<p class="text-md text-monokaiWhite">' . substr(string: $post->getBody(), offset: 0, length: 100) . '...</p>';
             $main .= '</a>';

--- a/php/views/Model/Post.php
+++ b/php/views/Model/Post.php
@@ -14,6 +14,7 @@ class Post
     private string $body;
     private string $created_at;
     private string $updated_at;
+    private string $user_name;
 
     public function __construct(
         int    $id,
@@ -22,7 +23,8 @@ class Post
         string $thumbnail,
         string $body,
         string $created_at,
-        string $updated_at
+        string $updated_at,
+        string $user_name
     )
     {
         $id_checked = new NumberInt($id);
@@ -40,6 +42,8 @@ class Post
         $this->created_at = $created_at;
 
         $this->updated_at = $updated_at;
+
+        $this->user_name = $user_name;
     }
 
     /**
@@ -84,5 +88,10 @@ class Post
     public function getUpdatedAt(): string
     {
         return $this->updated_at;
+    }
+
+    public function getUserName(): string
+    {
+        return $this->user_name;
     }
 }

--- a/php/views/Repository/RepositoryGetAllPost.php
+++ b/php/views/Repository/RepositoryGetAllPost.php
@@ -13,7 +13,21 @@ class RepositoryGetAllPost implements RepositoryInterface
 {
     public static function getAllPosts(): PostCollection
     {
-        $query = "SELECT * FROM post";
+        $query = <<<EOT
+            SELECT
+                p.id,
+                p.title,
+                p.user_id,
+                p.thumbnail,
+                p.body,
+                p.updated_at,
+                p.created_at,
+                u.name
+            FROM post p
+            JOIN users u
+            ON p.user_id = u.id
+            ORDER BY created_at DESC
+        EOT;
         $res = self::query_run($query);
         $posts = new PostCollection();
         foreach ($res as $post) {
@@ -24,7 +38,18 @@ class RepositoryGetAllPost implements RepositoryInterface
             $body = $post['body'];
             $updated_at = $post['updated_at'];
             $created_at = $post['created_at'];
-            $post = new Post($id, $title, $user_id, $thumbnail, $body, $updated_at, $created_at);
+            $user_name = $post['name'];
+
+            $post = new Post(
+                id: $id
+                , title: $title
+                , user_id: $user_id
+                , thumbnail: $thumbnail
+                , body: $body
+                , created_at: $created_at
+                , updated_at: $updated_at
+                , user_name: $user_name
+            );
             $posts->append($post);
         }
         return $posts;

--- a/php/views/Repository/RepositoryGetPostById.php
+++ b/php/views/Repository/RepositoryGetPostById.php
@@ -6,7 +6,7 @@ namespace App\Repository;
 
 use App\Core\CreateConnectionPDO;
 use App\Model\Post;
-use App\Model\PostCollection;
+use Exception;
 
 class RepositoryGetPostById implements RepositoryInterface
 {
@@ -31,7 +31,7 @@ class RepositoryGetPostById implements RepositoryInterface
         EOT;
         $post = self::query_run($query, $params);
         if (count($post) !== 1) {
-            throw new \Exception(message: "post not found");
+            throw new Exception(message: "post not found");
         }
 
         $id = $post[0]['id'];

--- a/php/views/Repository/RepositoryGetPostById.php
+++ b/php/views/Repository/RepositoryGetPostById.php
@@ -10,7 +10,7 @@ use App\Model\PostCollection;
 
 class RepositoryGetPostById implements RepositoryInterface
 {
-    public static function getPostById(string $id): PostCollection
+    public static function getPostById(string $id): Post
     {
         $params = ['id' => $id];
         $query = <<<EOT
@@ -29,31 +29,32 @@ class RepositoryGetPostById implements RepositoryInterface
             WHERE p.id = ?
             ORDER BY created_at DESC
         EOT;
-        $res = self::query_run($query, $params);
-        $posts = new PostCollection();
-        foreach ($res as $post) {
-            $id = $post['id'];
-            $title = $post['title'];
-            $user_id = $post['user_id'];
-            $thumbnail = $post['thumbnail'];
-            $body = $post['body'];
-            $updated_at = $post['updated_at'];
-            $created_at = $post['created_at'];
-            $user_name = $post['name'];
-
-            $post = new Post(
-                id: $id
-                , title: $title
-                , user_id: $user_id
-                , thumbnail: $thumbnail
-                , body: $body
-                , updated_at: $updated_at
-                , created_at: $created_at
-                , user_name: $user_name
-            );
-            $posts->append($post);
+        $post = self::query_run($query, $params);
+        if (count($post) !== 1) {
+            throw new \Exception(message: "post not found");
         }
-        return $posts;
+
+        $id = $post[0]['id'];
+        $title = $post[0]['title'];
+        $user_id = $post[0]['user_id'];
+        $thumbnail = $post[0]['thumbnail'];
+        $body = $post[0]['body'];
+        $updated_at = $post[0]['updated_at'];
+        $created_at = $post[0]['created_at'];
+        $user_name = $post[0]['name'];
+
+        $post = new Post(
+            id: $id
+            , title: $title
+            , user_id: $user_id
+            , thumbnail: $thumbnail
+            , body: $body
+            , updated_at: $updated_at
+            , created_at: $created_at
+            , user_name: $user_name
+        );
+
+        return $post;
     }
 
     public static function query_run(string $query, array $params = []): array

--- a/php/views/Repository/RepositoryGetPostById.php
+++ b/php/views/Repository/RepositoryGetPostById.php
@@ -13,7 +13,22 @@ class RepositoryGetPostById implements RepositoryInterface
     public static function getPostById(string $id): PostCollection
     {
         $params = ['id' => $id];
-        $query = "SELECT * FROM post WHERE id = ?";
+        $query = <<<EOT
+            SELECT
+                p.id,
+                p.title,
+                p.user_id,
+                p.thumbnail,
+                p.body,
+                p.updated_at,
+                p.created_at,
+                u.name
+            FROM post p
+            JOIN users u
+            ON p.user_id = u.id
+            WHERE p.id = ?
+            ORDER BY created_at DESC
+        EOT;
         $res = self::query_run($query, $params);
         $posts = new PostCollection();
         foreach ($res as $post) {
@@ -24,7 +39,18 @@ class RepositoryGetPostById implements RepositoryInterface
             $body = $post['body'];
             $updated_at = $post['updated_at'];
             $created_at = $post['created_at'];
-            $post = new Post($id, $title, $user_id, $thumbnail, $body, $updated_at, $created_at);
+            $user_name = $post['name'];
+
+            $post = new Post(
+                id: $id
+                , title: $title
+                , user_id: $user_id
+                , thumbnail: $thumbnail
+                , body: $body
+                , updated_at: $updated_at
+                , created_at: $created_at
+                , user_name: $user_name
+            );
             $posts->append($post);
         }
         return $posts;

--- a/php/views/Repository/RepositoryRegister.php
+++ b/php/views/Repository/RepositoryRegister.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Core\CreateConnectionPDO;
+use App\Core\StringArray;
+use InvalidArgumentException;
+use PDO;
 
 class RepositoryRegister
 {
@@ -14,22 +17,39 @@ class RepositoryRegister
         string $password_hashed
     ): void
     {
-        $query = "INSERT INTO users (name, email, password) VALUES (?,?,?)";
-        self::query_run(
-            query: $query
-            , user_name: $user_name
+        $user_names = self::getAllUserName();
+        if ($user_names->isExist($user_name)) {
+            throw new InvalidArgumentException(message: "user name already exists");
+        }
+
+        // code below have possible to throw PDOException
+        self::InsertUserData(
+            user_name: $user_name
             , email: $email
             , password_hashed: $password_hashed
         );
     }
 
-    public static function query_run(
-        string   $query
-        , string $user_name
+    public static function getAllUserName(): StringArray
+    {
+        // code below have possible to throw PDOException
+        $query = "SELECT name FROM users";
+        $db = CreateConnectionPDO::CreateConnection();
+        $prepared = $db->prepare($query);
+        $prepared->execute();
+        $user_names = $prepared->fetchAll(mode: PDO::FETCH_COLUMN, args: 0);
+
+        // code below have possible to throw Invalid Argument Exception
+        return new StringArray($user_names);
+    }
+
+    public static function InsertUserData(
+        string   $user_name
         , string $email
         , string $password_hashed
     ): void
     {
+        $query = "INSERT INTO users (name, email, password) VALUES (?,?,?)";
         $db = CreateConnectionPDO::CreateConnection();
         $prepared = $db->prepare($query);
         $prepared->execute([$user_name, $email, $password_hashed]);

--- a/php/views/Repository/RepositoryRegister.php
+++ b/php/views/Repository/RepositoryRegister.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Core\CreateConnectionPDO;
-use App\Core\StringArray;
+use App\Core\StringArrayChecker;
 use InvalidArgumentException;
 use PDO;
 
@@ -30,7 +30,7 @@ class RepositoryRegister
         );
     }
 
-    public static function getAllUserName(): StringArray
+    public static function getAllUserName(): StringArrayChecker
     {
         // code below have possible to throw PDOException
         $query = "SELECT name FROM users";
@@ -40,7 +40,7 @@ class RepositoryRegister
         $user_names = $prepared->fetchAll(mode: PDO::FETCH_COLUMN, args: 0);
 
         // code below have possible to throw Invalid Argument Exception
-        return new StringArray($user_names);
+        return new StringArrayChecker($user_names);
     }
 
     public static function InsertUserData(

--- a/php/views/Route.php
+++ b/php/views/Route.php
@@ -17,6 +17,7 @@ use App\Handler\HandlerPostNewPost;
 use App\Handler\HandlerPostPage;
 use App\Handler\HandlerRegister;
 use App\Handler\HandlerRegisterPage;
+use App\Handler\HandlerNotAuthor;
 use App\Handler\HandlerTopPage;
 use App\Handler\HandlerUpdatePost;
 
@@ -51,31 +52,34 @@ class Route
     {
         $uri = $req->getUri();
         $method = $req->getRequestMethod();
-        if ($uri === "/login" && $method === "GET") {
+        if ($uri === "/" && $method === "GET") {
+            $res = HandlerTopPage::run($req);
+        } else if ($uri === "/" && $method === "POST") {
+            $res = HandlerPostNewPost::run($req);
+        } else if ($uri === "/login" && $method === "GET") {
             $res = HandlerLoginPage::run($req);
         } else if ($uri === "/login" && $method === "POST") {
             $res = HandlerLogin::run($req);
         } else if ($uri === "/logout" && $method === "GET") {
             $res = HandlerLogout::run($req);
-        } else if ($uri === "/" && $method === "GET") {
-            $res = HandlerTopPage::run($req);
-        } else if ($uri === "/" && $method === "POST") {
-            $res = HandlerPostNewPost::run($req);
-        } else if (str_contains($uri, '/post') && $method === "GET") {
-            $res = HandlerPostPage::run($req);
-        } else if (str_contains($uri, '/post') && $req->getPostData()["_method"] === "delete") {
-            $res = HandlerDeletePost::run($req);
-        } else if (str_contains($uri, '/edit') && $method === "GET") {
-            $res = HandlerEditPost::run($req);
-        } else if (str_contains($uri, '/edit') && $req->getPostData()["_method"] === "put") {
-            $res = HandlerUpdatePost::run($req);
+        } else if ($uri === "/not-author") {
+            $res = HandlerNotAuthor::run($req);
         } else if ($uri === '/register' && $method === "GET") {
             $res = HandlerRegisterPage::run($req);
         } else if ($uri === '/register' && $method === "POST") {
             $res = HandlerRegister::run($req);
+        } else if (str_contains($uri, '/edit') && $method === "GET") {
+            $res = HandlerEditPost::run($req);
+        } else if (str_contains($uri, '/edit') && $req->getPostData()["_method"] === "put") {
+            $res = HandlerUpdatePost::run($req);
+        } else if (str_contains($uri, '/post') && $method === "GET") {
+            $res = HandlerPostPage::run($req);
+        } else if (str_contains($uri, '/post') && $req->getPostData()["_method"] === "delete") {
+            $res = HandlerDeletePost::run($req);
         } else {
             $res = HandlerNotFound::run();
         }
+
         return $res;
     }
 

--- a/php/views/Route.php
+++ b/php/views/Route.php
@@ -41,7 +41,7 @@ class Route
             "/login",
             "/register"
         ];
-        if (empty($_SESSION) && in_array(needle: $req->getUri(), haystack: $allowedPath) === false) {
+        if (empty($_SESSION['user_name']) && in_array(needle: $req->getUri(), haystack: $allowedPath) === false) {
             header(header: "Location: http://localhost:8080/login");
             exit();
         }
@@ -85,7 +85,7 @@ class Route
             header(header: "Location: http://localhost:8080/login", response_code: 301);
             exit();
         } else if ($res->getStatusCode() === "301" && $res->getRedirectLocation() === RedirectTarget::getHomePath()) {
-            $_SESSION['user_id'] = $req->getPostData()["username"];
+            $_SESSION['user_name'] = $req->getPostData()["username"];
             header(header: "Location: http://localhost:8080/", response_code: 301);
             exit();
         } else if ($res->getStatusCode() === "401" && $res->getRedirectLocation() === RedirectTarget::getLoginPath()) {

--- a/php/views/Route.php
+++ b/php/views/Route.php
@@ -12,12 +12,12 @@ use App\Handler\HandlerEditPost;
 use App\Handler\HandlerLogin;
 use App\Handler\HandlerLoginPage;
 use App\Handler\HandlerLogout;
+use App\Handler\HandlerNotAuthor;
 use App\Handler\HandlerNotFound;
 use App\Handler\HandlerPostNewPost;
 use App\Handler\HandlerPostPage;
 use App\Handler\HandlerRegister;
 use App\Handler\HandlerRegisterPage;
-use App\Handler\HandlerNotAuthor;
 use App\Handler\HandlerTopPage;
 use App\Handler\HandlerUpdatePost;
 
@@ -94,6 +94,10 @@ class Route
             exit();
         } else if ($res->getStatusCode() === "401" && $res->getRedirectLocation() === RedirectTarget::getLoginPath()) {
             header(header: "Location: http://localhost:8080/login");
+            exit();
+        } elseif ($res->getStatusCode() === "400" && $res->getRedirectLocation() === RedirectTarget::getRegisterPath()) {
+            $_SESSION["message"] = $res->getBody();
+            header(header: "Location: http://localhost:8080/register");
             exit();
         }
     }


### PR DESCRIPTION
見た目に変化はないです。

## Classの追加
以下の二つのClassを追加しました. 
- 前者は`/register`で登録に失敗したときに`/login`より`/register`に飛ばしたいと感じたからです.
- 後者はRepositoryで名前のデータを取得した際に`string[]`のような型が欲しくなったので作成しました. `__constructor`でvalidationをし, エラーを`App\Handler`の層で処理しています

[🏷️ [update types] => Redirectに/registerを追加しました](https://github.com/shunsock/kenshu-php/commit/e604d8b40ef51f3e941ffb92bec3b6f3d3f81553)
[🏷️ [add types] => arrayでしか扱えない値が出現したため, 型およびvalidationを実装しました](https://github.com/shunsock/kenshu-php/commit/45f68261c6c2dd8be543a0b0f43bcf854718b3f0)

## Postを著者以外が操作できないようにする
- `$_SESSION["name"]`とPostのusernameを見比べることで実現しました
[👔 [add business logic] => Postを著者以外が操作できないようにしました](https://github.com/shunsock/kenshu-php/commit/c0c771c36a407047ab73dcd5ace00cf65203029f)


## 新規登録画面でユーザー名が重複する際にエラーを投げる
- #14 で指摘が入っていた部分の修正です
- users tableのnameが重複してしまうのでエラーを投げるようにしました
- Repositoryで行っていますが, if ~ try ~のような構造になっていたためprivate functionにして分割しています
 
👔 [add business logic] => 新規登録画面でユーザー名が重複に対しルーティングとエラーの表示をするようにしました](https://github.com/shunsock/kenshu-php/commit/9e97da9ab95c3da316c0841b090754a4e6f3b84c)